### PR TITLE
WIP: First draft of integrating this with BigQuery

### DIFF
--- a/bigquery-etl.py
+++ b/bigquery-etl.py
@@ -1,0 +1,29 @@
+import sys
+from google.cloud import bigquery
+from fx_crash_sig.crash_processor import CrashProcessor
+
+QUERY_TEMPLATE = """
+SELECT
+  document_id, payload
+FROM
+  `moz-fx-data-shared-prod`.telemetry.crash
+WHERE
+  normalized_channel="nightly"
+  AND DATE(submission_timestamp)="{date}"
+  AND application.build_id > FORMAT_DATE("%Y%m%d", DATE_SUB(DATE "{date}", INTERVAL 1 WEEK))
+"""
+
+if len(sys.argv) != 2:
+    print("USAGE: %s <date in YYYY-MM-DD format>" % sys.argv[0])
+    sys.exit(1)
+
+proc = CrashProcessor(windows=True)
+
+client = bigquery.Client()
+query_job = client.query(QUERY_TEMPLATE.format(date=sys.argv[1]))
+result = query_job.result()
+for (document_id, payload) in result:
+    if payload:
+        symbolicated = proc.symbolicate(payload)
+        sig = proc.get_signature_from_symbolicated(symbolicated).signature
+        print(f"{document_id},{sig}")

--- a/fx_crash_sig/crash_processor.py
+++ b/fx_crash_sig/crash_processor.py
@@ -23,7 +23,7 @@ class CrashProcessor:
         return result
 
     def symbolicate(self, payload):
-        crash_data = payload.get('stackTraces', None)
+        crash_data = payload.get('stack_traces', None)
         if crash_data is None or len(crash_data) == 0:
             symbolicated = {}
         elif 'ipc_channel_error' in payload:
@@ -33,8 +33,7 @@ class CrashProcessor:
         else:
             symbolicated = self.symbolicator.symbolicate(crash_data)
 
-        metadata = payload['metadata']
-
+        metadata = payload.get('metadata') or {}
         meta_fields = {
             'ipc_channel_error': 'ipc_channel_error',
             'MozCrashReason': 'moz_crash_reason',

--- a/fx_crash_sig/crash_processor.py
+++ b/fx_crash_sig/crash_processor.py
@@ -1,9 +1,6 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-from __future__ import print_function
-
 import json
 from siggen.generator import SignatureGenerator
 

--- a/fx_crash_sig/symbolicate.py
+++ b/fx_crash_sig/symbolicate.py
@@ -76,10 +76,9 @@ class Symbolicator:
                 ip_int = int(src_frame['ip'], 16)
                 out_frame['offset'] = src_frame['ip']
 
-                if 'module_index' not in src_frame:
+                module_index = src_frame.get('module_index')
+                if module_index is None:
                     continue
-
-                module_index = src_frame['module_index']
                 if not (module_index >= 0 and module_index < len(modules)):
                     msg = "module_index " + module_index + " out of range for "
                     msg += "thread " + thread_idx + " frame " + frame_idx
@@ -164,7 +163,7 @@ class Symbolicator:
         symbolication_requests = {
             'jobs': [self.__try_get_sym_req(t) for t in traces]
         }
-        crashing_threads = [t['crash_info'].get('crashing_thread', 0) for
+        crashing_threads = [t['crash_info'].get('crashing_thread', 0) if t['crash_info'] else 0 for
                             t in traces]
 
         try:


### PR DESCRIPTION
This is a first attempt-- not sure if this is the right approach. But basically:

* Set GOOGLE_APPLICATION_CREDENTIALS=/path/to/service/account/file.json (the service account should be one on the `fx-crash-sig-bigquery-project`)
* Run `python bigquery-etl.py 2020-05-20 > out.csv` (this will take a while) 
* Insert CSV into BigQuery using the [bq command-line tool](https://docs.telemetry.mozilla.org/cookbooks/bigquery/access.html#from-bq-command-line-tool): `bq load test.crash_signature out.csv document_id:string,crash_signature:string`

Then from the BigQuery console in the `fx-crash-sig-bigquery-project`, you should be able to
do things like:

```sql
SELECT
  crash.application.build_id,
  crash_signature.crash_signature
FROM
  test.crash_signature
INNER JOIN
  `moz-fx-data-shared-prod`.telemetry.crash
ON
  crash.document_id = crash_signature.document_id
  AND DATE(submission_timestamp) = '2020-05-20';
```

And you'll get a map of build ids to (credible looking?) crash signatures. Note
this will only work after some point in mid-May, due to some schema issues (we can
backfill fixes at some point in the future if needed)

Still todo:
- [ ] Validate these crash signatures are remotely valid, fix any problems in fx-crash-sig
- [ ] Figure out if @willkg's symbolic might be useful here (he mentioned it when he found out I was working on this): https://bluesock.org/~willkg/blog/mozilla/experimenting_with_symbolic.html
- [ ] Run this as an actual airflow job (I can handle this horrible task once we're happy with the above)