### PR TITLE
Update docker version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,10 @@ jobs:
       - image: docker:stable-git
     steps:
       - checkout
-      - setup_remote_docker
+
+      - setup_remote_docker:
+          version: 19.03.13
+
       - run:
           name: Build Docker image
           command: docker build -t app:build .


### PR DESCRIPTION
This explicitly sets the Docker version. If we don't set the version, CircleCI defaults to using 17.03.0 which is a version that CircleCI is deprecating.

https://discuss.circleci.com/t/old-linux-machine-image-remote-docker-deprecation/37572