### PR TITLE
Fix AttributeErrors (#23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,12 @@ signature = crash_processor.get_signature(sample_traces.trace1)
 Command line (using [sample.json](/sample.json)):
 
 ```sh
-cat sample.json | fx-crash-sig
+$ cat sample.json | fx-crash-sig
+EMPTY: no crashing thread identified
 ```
 
 ```sh
-python example.py
+$ python example.py
 ```
 
 

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -6,4 +6,9 @@
 
 # Usage: bin/run_tests.sh
 
+echo ">>>Running pytest..."
 pytest tests/
+echo ""
+
+echo ">>> Testing fx-crash-sig command..."
+cat sample.json | fx-crash-sig

--- a/fx_crash_sig/crash_processor.py
+++ b/fx_crash_sig/crash_processor.py
@@ -46,7 +46,7 @@ class CrashProcessor:
 
         sigs = []
         for (payload, sym) in zip(payloads, symbolicated):
-            sym = self.__postprocess_symbolicated(payload, sym)
+            sym = self._postprocess_symbolicated(payload, sym)
             sigs.append(self.get_signature_from_symbolicated(sym))
         return sigs
 
@@ -61,9 +61,9 @@ class CrashProcessor:
         else:
             symbolicated = self.symbolicator.symbolicate(crash_data)
 
-        return self.__postprocess(payload, symbolicated)
+        return self._postprocess_symbolicated(payload, symbolicated)
 
-    def __postprocess_symbolicated(self, payload, symbolicated):
+    def _postprocess_symbolicated(self, payload, symbolicated):
         metadata = payload.get("metadata") or {}
         meta_fields = {
             "ipc_channel_error": "ipc_channel_error",


### PR DESCRIPTION
This fixes an attribute error when printing out details of an unhandled exception when using the fx-crash-sig command.

This fixes the attribute error caused by some parts of the code still using a non-existent `__postprocess` method.

This fixes the problem where siggen now returns a Result object which isn't serializable and so it doesn't work with json.dumps.

Fixes #23