### PR TITLE
Python3 cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,12 +56,16 @@ jobs:
       - checkout
 
       - run:
-          name: Install tox
-          command: pip install tox
+          name: Install requirements
+          command: pip install -r requirements.dev.txt
 
       - run:
-          name: Test and lint
-          command: tox -e py36,py37,py38,py36-lint
+          name: Test
+          command: tox -e py36,py37,py38
+
+      - run:
+          name: Lint
+          command: bin/run_lint.sh
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,9 @@ jobs:
             - /cache/docker.tar
 
   # Test and lint the Python library in supported Python environments
+  #
+  # NOTE(willkg): This doesn't test >=3.9 because themattrix/tox doesn't
+  # support that, yet: https://github.com/themattrix/docker-tox/issues/22
   test-library:
     docker:
       - image: themattrix/tox
@@ -58,7 +61,7 @@ jobs:
 
       - run:
           name: Test and lint
-          command: tox
+          command: tox -e py36,py37,py38,py36-lint
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,4 @@
+---
 version: 2.1
 orbs:
   gcp-gcr: circleci/gcp-gcr@0.7.1
@@ -6,7 +7,8 @@ commands:
   restore-docker:
     description: Restore Docker image cache
     steps:
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 19.03.13
       - restore_cache:
           key: v1-{{.Branch}}
       - run:
@@ -14,9 +16,11 @@ commands:
           command: docker load -i /cache/docker.tar
 
 jobs:
-  build:
+  # Build and test the Docker image
+  build-docker:
     docker:
       - image: docker:stable-git
+
     steps:
       - checkout
 
@@ -26,47 +30,47 @@ jobs:
       - run:
           name: Build Docker image
           command: docker build -t app:build .
+
+      - run:
+          name: Test Code
+          command: docker run app:build /app/bin/run_tests.sh
+
       - run:
           name: docker save app:build
           command: mkdir -p /cache; docker save -o /cache/docker.tar "app:build"
+
       - save_cache:
           key: v1-{{ .Branch }}-{{epoch}}
           paths:
             - /cache/docker.tar
 
-  test:
-    docker: &docker
-      - image: docker:18.06.0-ce
-    steps:
-      - restore-docker
-      - run:
-          name: Test Code
-          command: docker run app:build /app/bin/run_tests.sh
+  # Test and lint the Python library in supported Python environments
+  test-library:
+    docker:
+      - image: themattrix/tox
 
-  lint:
-    docker: *docker
     steps:
-      - restore-docker
+      - checkout
+
       - run:
-          name: Lint Code
-          command: docker run app:build /app/bin/run_lint.sh
+          name: Install tox
+          command: pip install tox
+
+      - run:
+          name: Test and lint
+          command: tox
 
 workflows:
   version: 2
   main:
     jobs:
-      - build
+      - build-docker
 
-      - test:
-          requires:
-            - build
-
-      - lint:
-          requires:
-            - build
+      - test-library
 
 #       - gcp-gcr/build-and-push-image:
-#           # See https://bugzilla.mozilla.org/show_bug.cgi?id=1608957 for details
+#           # See https://bugzilla.mozilla.org/show_bug.cgi?id=1608957 for
+#           # details
 #           context: data-eng-airflow-gcr
 #           image: fx-crash-sig
 #           requires:

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ __pycache__
 build
 dist
 fx_crash_sig.egg-info/
+.tox
+.python-version

--- a/Makefile
+++ b/Makefile
@@ -48,5 +48,5 @@ reformat:  ## | Reformat code
 	docker-compose run --rm app /app/bin/run_lint.sh --reformat
 
 .PHONY: test
-test:  ## | Run tests
+test:  ## | Run tests in docker environment
 	docker-compose run --rm app /app/bin/run_tests.sh

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ make lint
 make reformat
 ```
 
-Test:
+Test docker environment:
 
 ```sh
 make test
@@ -72,6 +72,15 @@ make test
 If you have problems with file permissions when using the Docker image, edit
 your `.env` file and change the `USER_ID` and `GROUP_ID` values to match your
 uid and gid.
+
+Test against Python versions:
+
+```sh
+tox
+```
+
+Note: This requires you have Python environments set up and a virtual
+environment with tox installed.
 
 
 ## Release process

--- a/bin/run_lint.sh
+++ b/bin/run_lint.sh
@@ -20,8 +20,7 @@ if [[ $1 == "--reformat" ]]; then
 
 else
     echo ">>> flake8 ($(python --version))"
-    cd /app
-    flake8
+    flake8 fx_crash_sig tests
 
     echo ">>> black"
     black --check "${BLACKARGS[@]}"

--- a/example.py
+++ b/example.py
@@ -2,8 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import print_function
-
 import ujson as json
 
 from fx_crash_sig import sample_traces

--- a/fx_crash_sig/cmd_get_crash_sig.py
+++ b/fx_crash_sig/cmd_get_crash_sig.py
@@ -2,8 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import print_function
-
 import argparse
 import sys
 

--- a/fx_crash_sig/crash_processor.py
+++ b/fx_crash_sig/crash_processor.py
@@ -1,8 +1,10 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import json
 import sys
+
 from siggen.generator import SignatureGenerator
 
 from fx_crash_sig import SYMBOLS_API

--- a/fx_crash_sig/symbolicate.py
+++ b/fx_crash_sig/symbolicate.py
@@ -2,11 +2,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import print_function
+from itertools import islice
+import sys
 
 import requests
-import sys
-from itertools import islice
 
 from fx_crash_sig import SYMBOLS_API
 

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -2,6 +2,7 @@
 black==20.8b1
 flake8==3.8.4
 pytest==6.1.2
+tox==3.20.1
 
 # requirements for building and pushing package files
 twine==3.2.0

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,10 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
         "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Development Status :: 2 - Pre-Alpha",
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,17 @@
+[tox]
+envlist = py36,py37,py38,py39,py36-lint
+
+[testenv]
+commands =
+    pip install -r requirements.dev.txt
+    bash bin/run_tests.sh
+allowlist_externals =
+    bash
+
+[testenv:py36-lint]
+basepython = python3.6
+commands =
+    pip install -r requirements.dev.txt
+    bash bin/run_lint.sh
+allowlist_externals =
+    bash


### PR DESCRIPTION
This removes `__future__` imports since this only supports Python 3 now.

This adds some of the bits we need to support Python 3.6 -> 3.9: a tox configuration and tweaks to scripts to run in a tox environment.

This doesn't change CircleCI to run tox as part of the CI run. Since CircleCI is currently configured to run tests and linting in the Docker image, I'm not sure offhand how best to also run tox in a different environment that has Python 3.6 through 3.9 installed. I'm thinking I may add another job that uses `themattrix/tox` image. It just feels clunky.