### PR TITLE
Add support for Python 3.10 and 3.11 (#41) (#42)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,14 +17,14 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     name: Python ${{ matrix.python-version}}
     steps:
-      - uses: actions/checkout@v2.3.5
+      - uses: actions/checkout@v2.5.0
 
       - name: Set up Python
-        uses: actions/setup-python@v2.2.2
+        uses: actions/setup-python@v2.3.3
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,8 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Development Status :: 2 - Pre-Alpha",
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,13 @@
 [tox]
-envlist = py37,py38,py39
+envlist = py37,py38,py39,py310,py311
 
 [gh-actions]
 python =
     3.7: py37
     3.8: py38
     3.9: py39
+    3.10: py310
+    3.11: py311
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
This also updates the actions/setup-python and actions/checkout github action steps.

Fixes #41. Fixes #42.