### PR TITLE
Add "reason" to symbolication output structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ cat sample.json | fx-crash-sig
 
 ## Minimal crash ping structure
 
+The crash ping is documented here:
+
+https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/data/crash-ping.html
+
 These are the parts of the crash ping we use:
 
 ```
@@ -54,6 +58,7 @@ These are the parts of the crash ping we use:
   - stack_traces:
     - crash_info:
       - crashing_thread
+      - type
     - modules[]
       - debug_file
       - debug_id

--- a/fx_crash_sig/cmd_get_crash_sig.py
+++ b/fx_crash_sig/cmd_get_crash_sig.py
@@ -27,13 +27,9 @@ def cmdline():
             print("fx-crash-sig: Failed: Invalid input format")
         return
 
-    try:
-        result = crash_processor.get_signature(payload)
-        if result is not None:
-            print(f"signature: {result.signature}")
-            print(f"notes:     ({len(result.notes)})")
-            for note in result.notes:
-                print(f"           * {note}")
-    except Exception as exc:
-        if args.verbose:
-            print(f"fx-crash-sig: Failed: {exc!r}")
+    result = crash_processor.get_signature(payload)
+    if result is not None:
+        print(f"signature: {result.signature}")
+        print(f"notes:     ({len(result.notes)})")
+        for note in result.notes:
+            print(f"           * {note}")

--- a/tests/test_crash_processor.py
+++ b/tests/test_crash_processor.py
@@ -1,0 +1,19 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from fx_crash_sig.crash_processor import deep_get
+
+
+@pytest.mark.parametrize(
+    "structure, path, expected",
+    [
+        ({}, "a.b.c", None),
+        ({"a": 5}, "a", 5),
+        ({"a": {"b": 5}}, "a.b", 5),
+    ],
+)
+def test_deep_get(path, structure, expected):
+    assert deep_get(structure, path) == expected


### PR DESCRIPTION
This adds reason to the symbolication output structure taken from stack_traces.crash_info.type. This is used by signature generation--it's one of the things it looks at to flag OOM crashes.

Fixes #37.