### PR TITLE
Handle no function case correctly (#72)

### DIFF
--- a/fx_crash_sig/crash_processor.py
+++ b/fx_crash_sig/crash_processor.py
@@ -30,13 +30,14 @@ class CrashProcessor:
         if self.verbose:
             print("Symbolicated stack:")
             for frame in symbolicated["threads"][0]["frames"]:
-                if frame.get("filename") and frame.get("line"):
-                    # FIXME(willkg): find actual keys
-                    print(
-                        f"   {frame['frame']}    {frame['function']}  ({frame['filename']}:{frame['line']})"
-                    )
+                frame_idx = frame.get("frame", "")
+                line = frame.get("line", "")
+                filename = frame.get("filename", "")
+                function = frame.get("function", "")
+                if filename and line:
+                    print(f"   {frame_idx}    {function}  ({filename}:{line})")
                 else:
-                    print(f"   {frame['frame']}    {frame['function']}")
+                    print(f"   {frame_idx}    {function}")
         signature_result = self.get_signature_from_symbolicated(symbolicated)
         if self.verbose and len(signature_result.signature) == 0:
             print(


### PR DESCRIPTION
This changes fx-crash-sig such that if the frame doesn't have a function key, it prints an empty string rather than throwing an unhandled exception.

Fixes #72